### PR TITLE
return a default if translation missing

### DIFF
--- a/src/vocab/services/yandex-dictionary.js
+++ b/src/vocab/services/yandex-dictionary.js
@@ -46,6 +46,14 @@ export default function yandexDefine(text, lang, targetLang) {
     .then(data => {
       if (data && data.def && data.def.length) return data;
 
-      throw new Error('No data');
+      return {
+        def: [
+          {
+            text: text, pos: "verb", ts: "-", tr: [
+              {text: "?", pos: "verb"}
+            ]
+          }
+        ]
+      }  
     });
 }


### PR DESCRIPTION
yandex is often not finding a translation for some portugues words that i'm trying to lookup and there is no way to recover from it, the whole thing throws an error and stops and can't be continued. this is not an ideal patch (although it does work), but just wanted to raise the issue.