### PR TITLE
Change casing of import paths for shared/services/Utils

### DIFF
--- a/src/vocab/components/Context/Context.jsx
+++ b/src/vocab/components/Context/Context.jsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { escapeRegexp } from '../../../shared/services/utils';
+import { escapeRegexp } from '../../../shared/services/Utils';
 import Editable from '../Editable/Editable.jsx';
 
 

--- a/src/vocab/services/csv.js
+++ b/src/vocab/services/csv.js
@@ -1,4 +1,4 @@
-import { escapeRegexp } from '../../shared/services/utils';
+import { escapeRegexp } from '../../shared/services/Utils';
 import { getArticle } from './formating';
 
 function formatWord(item) {


### PR DESCRIPTION
Hey, thanks for making this tool.

I was trying to give it a run to debug something (might be an issue with my vocab.db / dictionary setup). On non-Windows platforms, the import path here is case sensitive. I'm not sure if the solution you want here is to rename Utils.js to utils.js or to change the import paths, but nonetheless this allows `yarn start` to work on Linux.