### PR TITLE
Fix missing onChange on HeadWord

### DIFF
--- a/src/vocab/components/Words/Words.jsx
+++ b/src/vocab/components/Words/Words.jsx
@@ -38,6 +38,19 @@ export default class Words extends PureComponent {
     this.setState({ exportType });
   }
 
+  changeHeadWord(item, value) {
+    VocabStore.updateItem(this.props.id, item, {
+      selection: value,
+      def: item.def.map(defSubitem => {
+        return {
+          ...defSubitem,
+          // Rewrite def with new selection value.
+          text: value,
+        };
+      })
+    });
+  }
+
   changeDef(item, value) {
     VocabStore.updateItem(this.props.id, item, { def: [
       {
@@ -154,6 +167,7 @@ export default class Words extends PureComponent {
             <HeadWord
               lang={ deck.lang }
               def={ item.def }
+	      onChange={ val => this.changeHeadWord(item, val) }
             />
           </div>
 

--- a/src/vocab/components/Words/Words.jsx
+++ b/src/vocab/components/Words/Words.jsx
@@ -167,7 +167,7 @@ export default class Words extends PureComponent {
             <HeadWord
               lang={ deck.lang }
               def={ item.def }
-	      onChange={ val => this.changeHeadWord(item, val) }
+              onChange={ val => this.changeHeadWord(item, val) }
             />
           </div>
 


### PR DESCRIPTION
## Bug description
While working on another issue, I found that editing the HeadWord actually does nothing at the moment -- there is an error in the console for this.props.onChange not being a function (due to nothing actually being passed).

## In this change
This PR adds an onChange that updates both `selection` and any associated defs in `VocabStore` when it's edited. `sub()` automatically keeps the two in sync afterwards.

## Other notes
I didn't know how you want it to interface with non-kindle definitions -- this might cause some unintended interaction -- or perhaps it's intended that the def.text and the selection can be out of sync. But it seems to me that logically if a user is editing the words, they'd expect to edit the word of the associated definitions as well.

As background, I found this while trying to fix part of the "Fetch Definitions" button -- I was trying to test something by editing a word and then clicking "Fetch definition"; however, this still caused it to fetch the definition for the word before I edited it (which seems to me like it would be counterintuitive to a user). (See line 77: when it looks up a word, it does `const text = word.def && word.def[0] ? word.def[0].text : word.selection;`, first relying on `def[0]` if it exists`.)