### PR TITLE
Change "Fetch definitions" to keep fetching even after first failure

### DIFF
--- a/src/vocab/components/Definition/Definition.jsx
+++ b/src/vocab/components/Definition/Definition.jsx
@@ -12,12 +12,12 @@ export default class Definition extends PureComponent {
     const maxDefs = 2;
     const { def } = this.props;
 
-    const defintions = [];
-    def.forEach(item => item.tr ? item.tr.forEach(tr => defintions.push(tr.text)) : '');
+    const definitions = [];
+    def.forEach(item => item.tr ? item.tr.forEach(tr => definitions.push(tr.text)) : '');
 
     return (
       <Editable
-        text={ defintions.slice(0, maxDefs).join('; ') }
+        text={ definitions.slice(0, maxDefs).join('; ') }
         onChange={ this.props.onChange }
       />
     );

--- a/src/vocab/components/Words/Words.css
+++ b/src/vocab/components/Words/Words.css
@@ -108,6 +108,11 @@
 .exportButton:hover {
   border-color: #333;
 }
+.exportButton:disabled,
+.exportButton[disabled] {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
 
 .controls {
   display: flex;

--- a/src/vocab/components/Words/Words.jsx
+++ b/src/vocab/components/Words/Words.jsx
@@ -13,6 +13,14 @@ import styles from './Words.css';
 
 
 /**
+ * In order not to unnecessarily spam the API or potentially risk having any API
+ * keys locked, we limit the number of consecutive failures allowed on word
+ * lookups. After this many failures, we assume there is something wrong with
+ * the user's dictionary or language config.
+ */
+const MAX_CONSECUTIVE_LOOKUP_FAILURES = 10;
+
+/**
  * Words component
  */
 export default class Words extends PureComponent {
@@ -22,16 +30,27 @@ export default class Words extends PureComponent {
     this.state = {
       deck: null,
       exportType: null,
-      isReversed: false
+      isReversed: false,
+      isFetchingDefinitions: false,
     };
 
     this._toggleReverse = () => this.setState({ isReversed: !this.state.isReversed });
   }
 
   fetchDefinitions() {
-    if (this.state.deck) {
-      this.addDefinitions(this.state.deck);
+    if (!this.state.deck || this.state.isFetchingDefinitions) {
+      return;
     }
+    // Reset the lookup failure counter for each attempt of retrieving
+    // definitions, in case the underlying data has been fixed since a past
+    // failure.
+    this.setState(state => ({
+      isFetchingDefinitions: true,
+    }));
+
+    this.addDefinitions(this.state.deck, () => {
+      this.setState({isFetchingDefinitions: false});
+    });
   }
 
   exportDeck(exportType) {
@@ -55,23 +74,38 @@ export default class Words extends PureComponent {
     VocabStore.removeItem(this.props.id, item);
   }
 
-  addDefinitions(deck) {
+  addDefinitions(deck, setIsFinishedFetching) {
     const words = deck.words.filter(word => {
       return word.selection && (!word.def || !word.def[0] || !word.def[0].tr || !word.def[0].tr.length);
     });
+    let lookupFailureStreak = 0;
 
     const updateWord = word => {
       const text = word.def && word.def[0] ? word.def[0].text : word.selection;
 
       return lookup(text, deck.lang)
         .then(data => {
+          // No definition was found.
+          if (!data) {
+            lookupFailureStreak++;
+            return;
+          }
           VocabStore.updateItem(this.props.id, word, { def: data.def });
+          lookupFailureStreak = 0;
         });
     };
 
+    // Loop using a setTimeout to prevent overly high API hit rates.
     const loop = index => {
       const word = words[index];
-      if (!word) return;
+      if (!word) {
+        setIsFinishedFetching();
+        return;
+      }
+      if (lookupFailureStreak > MAX_CONSECUTIVE_LOOKUP_FAILURES) {
+        setIsFinishedFetching();
+        return;
+      }
 
       updateWord(word).then(() => {
         setTimeout(() => {
@@ -121,8 +155,8 @@ export default class Words extends PureComponent {
 
     const controls = (
       <div className={ styles.controls }>
-        <button className={ styles.exportButton } onClick={ () => this.fetchDefinitions() }>
-          Fetch definitions
+        <button className={ styles.exportButton } onClick={ () => this.fetchDefinitions() } disabled={this.state.isFetchingDefinitions}>
+          {!this.state.isFetchingDefinitions ? 'Fetch definitions' : 'Fetching...'}
         </button>
 
         <div className={ styles.spacer } />

--- a/src/vocab/services/lookup.js
+++ b/src/vocab/services/lookup.js
@@ -1,10 +1,16 @@
 import yandexDefine from './yandex-dictionary.js';
 import wordsApiDefine from './words-api.js';
 
+/**
+ * Load the definition of a word, potentially trying different APIs.
+ *
+ * @returns {promise} A promise that either contains an object with information
+ * about the definition or null if the word was not found.
+ */
 const load = (word, lang, targetLang) => {
   return (lang == 'en' && targetLang == 'en') ?
     wordsApiDefine(word).catch(() => yandexDefine(word, lang, targetLang)) :
-    yandexDefine(word, lang, targetLang);
+    yandexDefine(word, lang, targetLang).catch(() => null);
 };
 
 export function lookup(word, lang, targetLang='en') {


### PR DESCRIPTION
## Bug description
Currently, if you are using the yandex API, it does a `throw Error` when no data is found for some word, which then interrupts and prevents it from looking up any further words. Basically, it stops fetching definitions if you have a single erroneous word.

For example, şişmanca in the picture below is, for some reason, not translatable by Yandex. Thus this stops immediately on the first word, and fetches no other words.

![image](https://user-images.githubusercontent.com/1303401/110683968-81765d80-81d4-11eb-94ab-23d877be6658.png)

## This change
* Changes the Yandex fallback to return "null" if no word is found rather than throwing an error.
* The UI interprets null as meaning no word is found, but will still continue if this happens. However, it adds a rate-limiting mechanism still to prevent any configuration issues with languages etc to cause potentially hundreds of failed API calls -- there is a MAX_CONSECUTIVE_FAILED_LOOKUPS parameter.
* Disable the "Fetch definitions" button while in the process of fetching; prevent multiple refetches by spam-clicking.

## Misc changes
* Cleans up a typo in the word "definitions"

Tested this on my vocab.db with success -- it basically fetches definitions for those it can fetch for. Also see #5 -- which is useful for creating words you can't fetch definitions for.