### PR TITLE
fix: suppress the warning

### DIFF
--- a/src/vocab/components/Editable/Editable.jsx
+++ b/src/vocab/components/Editable/Editable.jsx
@@ -59,6 +59,7 @@ export default class Editable extends PureComponent {
       <span
         ref={ el => this.input = el }
         contentEditable
+        suppressContentEditableWarning
         className={ classes }
         onBlur={ this._onBlur }
         onKeyDown={ this._onKeyDown }


### PR DESCRIPTION
Suppress the warning for the ContentEditable: 
![Screenshot 2021-06-17 at 12 06 29](https://user-images.githubusercontent.com/11226631/122376457-76199780-cf64-11eb-84de-4f316dae3b85.png)
